### PR TITLE
update to Guzzle 6

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+{
+  "generalSettings": {
+    "shouldScanRepo": true
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure"
+  }
+}

--- a/.whitesource
+++ b/.whitesource
@@ -1,8 +1,0 @@
-{
-  "generalSettings": {
-    "shouldScanRepo": true
-  },
-  "checkRunSettings": {
-    "vulnerableCheckRunConclusionLevel": "failure"
-  }
-}

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+{
+  "generalSettings": {
+    "shouldScanRepo": false
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure"
+  }
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 SIL International
+Copyright (c) 2020 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,12 @@
   "license": "MIT",
   "require": {
     "php": ">=5.4.0",
-    "guzzlehttp/guzzle": "^5.3.1 || ^6.5.3",
     "guzzlehttp/guzzle-services": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "ext-json": "*",
+    "phpunit/phpunit": "~4.0",
+    "roave/security-advisories": "dev-master"
   },
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
   "require": {
     "php": ">=5.4.0",
     "guzzlehttp/guzzle": "^5.3.1 || ^6.5.3",
-    "guzzlehttp/guzzle-services": "*",
-    "guzzlehttp/retry-subscriber": "*"
+    "guzzlehttp/guzzle-services": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "require": {
     "php": ">=5.4.0",
-    "guzzlehttp/guzzle": "^5.3.1",
+    "guzzlehttp/guzzle": "^5.3.1 || ^6.5.3",
     "guzzlehttp/guzzle-services": "*",
     "guzzlehttp/retry-subscriber": "*",
     "guzzlehttp/log-subscriber": "*"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["jira","atlassian", "JIRA"],
   "license": "MIT",
   "require": {
-    "php": ">=5.4.0",
+    "php": ">=7.2.0",
     "guzzlehttp/guzzle-services": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
     "php": ">=5.4.0",
     "guzzlehttp/guzzle": "^5.3.1 || ^6.5.3",
     "guzzlehttp/guzzle-services": "*",
-    "guzzlehttp/retry-subscriber": "*",
-    "guzzlehttp/log-subscriber": "*"
+    "guzzlehttp/retry-subscriber": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"

--- a/src/Client.php
+++ b/src/Client.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Command\Guzzle\Description;
  * @method array getUser(array $config = [])
  * @method array addUser(array $config = [])
  * @method array updateUser(array $config = [])
+ * @method array searchForUser(array $config = [])
  * @method array deleteUser(array $config = [])
  * @method array deactivateUser(array $config = [])
  * @method array activateUser(array $config = [])
@@ -28,15 +29,18 @@ class Client extends GuzzleClient
             'description_path' => __DIR__ . '/jira-api.php',
         ];
 
+        // Ensure that the credentials are set.
+        $this->applyCredentials($config);
+
         // Create the Jira client.
         parent::__construct(
             $this->getHttpClientFromConfig($config),
             $this->getDescriptionFromConfig($config),
+            null,
+            null,
+            null,
             $config
         );
-
-        // Ensure that the credentials are set.
-        $this->applyCredentials($config);
 
         // Ensure that ApiVersion is set.
         $this->setConfig(
@@ -95,9 +99,11 @@ class Client extends GuzzleClient
             );
         }
 
-        // Set credentials for authentication based on Jira's requirements.
-        $this->getHttpClient()->setDefaultOption('auth', [
+        $config['auth'] = [
             $config['apiuser'], $config['apipass']
-        ]);
+        ];
+
+        // Return new config array with credentials for authentication based on Jira's requirements.
+        return $config;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -90,12 +90,12 @@ class Client extends GuzzleClient
         // Ensure that the credentials have been provided.
         if (!isset($config['apiuser'])) {
             throw new \InvalidArgumentException(
-                'You must provide a apiuser.'
+                'You must provide an apiuser.'
             );
         }
         if (!isset($config['apipass'])) {
             throw new \InvalidArgumentException(
-                'You must provide a apipass.'
+                'You must provide an apipass.'
             );
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,7 +4,6 @@ namespace Jira;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
 use GuzzleHttp\Command\Guzzle\Description;
-use GuzzleHttp\Subscriber\Retry\RetrySubscriber;
 
 /**
  * Partial Jira API client implemented with Guzzle.
@@ -58,15 +57,6 @@ class Client extends GuzzleClient
             ? $config['http_client_options']
             : [];
         $client = new HttpClient($clientOptions);
-
-        // Attach request retry logic.
-        $client->getEmitter()->attach(new RetrySubscriber([
-            'max' => $config['max_retries'],
-            'filter' => RetrySubscriber::createChainFilter([
-                RetrySubscriber::createStatusFilter(),
-                RetrySubscriber::createCurlFilter(),
-            ]),
-        ]));
 
         return $client;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,6 @@ class Client extends GuzzleClient
     {
         // Apply some defaults.
         $config += [
-            'max_retries'      => 3,
             'description_path' => __DIR__ . '/jira-api.php',
         ];
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -44,8 +44,10 @@ class Client extends GuzzleClient
 
         // Ensure that ApiVersion is set.
         $this->setConfig(
-            'defaults/ApiVersion',
-            $this->getDescription()->getApiVersion()
+            'defaults',
+            [
+                'ApiVersion' => $this->getDescription()->getApiVersion()
+            ]
         );
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,7 +30,7 @@ class Client extends GuzzleClient
         ];
 
         // Ensure that the credentials are set.
-        $this->applyCredentials($config);
+        $config = $this->applyCredentials($config);
 
         // Create the Jira client.
         parent::__construct(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -28,7 +28,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                     "groups"=> [],
         ]);
 
-        $client = $this->getMockClient($mockBody, 200);
+        $client = $this->getMockClient($mockBody);
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->getUser(['username' => 'test_user']);
@@ -70,7 +70,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             "displayName"=> "Test User",
         ]);
 
-        $client = $this->getMockClient($mockBody, 200);
+        $client = $this->getMockClient($mockBody);
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->updateUser([
@@ -114,7 +114,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             "active" => true
         ]);
 
-        $client = $this->getMockClient($mockBody, 200);
+        $client = $this->getMockClient($mockBody);
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->searchForUser([
@@ -124,11 +124,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("test_user", $user['key']);
     }
 
-    /**
-     * @param $mockBody
-     * @return Client
-     */
-    private function getMockClient($mockBody, $responseCode)
+    private function getMockClient(string $mockBody, int $responseCode = 200) : Client
     {
         $config = include 'config-test.php';
 
@@ -137,11 +133,11 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $handlerStack = HandlerStack::create($mockHandler);
-        $client = new Client(array_merge([
+
+        return new Client(array_merge([
             'http_client_options' => [
                 'handler' => $handlerStack,
             ]
         ], $config));
-        return $client;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -31,7 +31,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client = $this->getMockClient($mockBody, 200);
 
         // Call get user and make sure we get back the user we expect from mock
-        $user = $client->getUser(['username' => 'test_user', 'ApiVersion' => 'latest']);
+        $user = $client->getUser(['username' => 'test_user']);
 
         $this->assertEquals("test_user", $user['name']);
     }
@@ -50,7 +50,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->addUser([
-            'ApiVersion' => 'latest',
             "name" => "test_user",
             "emailAddress" => "test_user@domain.org",
             "displayName" => "Test User",
@@ -75,7 +74,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->updateUser([
-            'ApiVersion' => 'latest',
             "username" => "test_user",
             "emailAddress" => "test_112345455433@domain.org",
             "displayName" => "user display name",
@@ -93,7 +91,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->deleteUser([
-            'ApiVersion' => 'latest',
             "username" => "test_user",
         ]);
 
@@ -121,7 +118,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->searchForUser([
-            'ApiVersion' => 'latest',
             "username" => "test_user",
         ]);
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,10 +1,10 @@
 <?php
 namespace tests;
 
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
 use Jira\Client;
-use GuzzleHttp\Subscriber\Mock;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,11 +12,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $config = include 'config-test.php';
 
-        $client = new Client($config);
-
-        $mockBody = Stream::factory(
-            json_encode(
-                [
+        $mockBody = json_encode([
                     "self" => "http://www.example.com/jira/rest/api/2/user?username=test_user",
                     "name" => "test_user",
                     "emailAddress" => "test_user@domain.org",
@@ -30,178 +26,126 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                     "active"=> true,
                     "timeZone"=> "Australia/Sydney",
                     "groups"=> [],
-                ]
-            )
-        );
+        ]);
 
-        $mock = new Mock(
-            [
-                new Response(200, [], $mockBody),
-            ]
-        );
-
-        // Add the mock subscriber to the client.
-        $client->getHttpClient()->getEmitter()->attach($mock);
+        $client = $this->getMockClient($mockBody, 200);
 
         // Call get user and make sure we get back the user we expect from mock
-        $user = $client->getUser(['username' => "test_user"]);
+        $user = $client->getUser(['username' => 'test_user', 'ApiVersion' => 'latest']);
 
         $this->assertEquals("test_user", $user['name']);
     }
 
     public function testAddUser()
     {
-        $config = include 'config-test.php';
+        $mockBody = json_encode([
+            "self" => "http://www.example.com/jira/rest/api/2/user?username=test_user",
+            "name" => "test_user",
+            "key" => "test_user",
+            "emailAddress" => "test_user@domain.org",
+            "displayName"=> "Test User",
+        ]);
 
-        $client = new Client($config);
-
-
-        $mockBody = Stream::factory(
-            json_encode(
-                [
-                    "self" => "http://www.example.com/jira/rest/api/2/user?username=test_user",
-                    "name" => "test_user",
-                    "key" => "test_user",
-                    "emailAddress" => "test_user@domain.org",
-                    "displayName"=> "Test User",
-                ]
-            )
-        );
-
-        $mock = new Mock(
-            [
-                new Response(201, [], $mockBody),
-            ]
-        );
-
-        // Add the mock subscriber to the client.
-        $client->getHttpClient()->getEmitter()->attach($mock);
+        $client = $this->getMockClient($mockBody, 201);
 
         // Call get user and make sure we get back the user we expect from mock
-        $user = $client->addUser(
-            [
-                "name" => "test_user",
-                "emailAddress" => "test_user@domain.org",
-                "displayName" => "Test User",
-                "password" => "password123",
-                "active" => true // This isn't implemented in their api yet, but we're hopeful!
-            ]
-        );
+        $user = $client->addUser([
+            'ApiVersion' => 'latest',
+            "name" => "test_user",
+            "emailAddress" => "test_user@domain.org",
+            "displayName" => "Test User",
+            "password" => "password123",
+            "active" => true // This isn't implemented in their api yet, but we're hopeful!
+        ]);
 
         $this->assertEquals("test_user", $user['key']);
     }
 
-
     public function testUpdateUser()
     {
-        $config = include 'config-test.php';
+        $mockBody = json_encode([
+            "self" => "http://www.example.com/jira/rest/api/2/user?username=test_user",
+            "name" => "test_user",
+            "key" => "test_user",
+            "emailAddress" => "test_user@domain.org",
+            "displayName"=> "Test User",
+        ]);
 
-        $client = new Client($config);
-
-        $mockBody = Stream::factory(
-            json_encode(
-                [
-                    "self" => "http://www.example.com/jira/rest/api/2/user?username=test_user",
-                    "name" => "test_user",
-                    "key" => "test_user",
-                    "emailAddress" => "test_user@domain.org",
-                    "displayName"=> "Test User",
-                ]
-            )
-        );
-
-        $mock = new Mock(
-            [
-                new Response(200, [], $mockBody),
-            ]
-        );
-
-        // Add the mock subscriber to the client.
-        $client->getHttpClient()->getEmitter()->attach($mock);
+        $client = $this->getMockClient($mockBody, 200);
 
         // Call get user and make sure we get back the user we expect from mock
-        $user = $client->updateUser(
-            [
-                "username" => "test_user",
-                "emailAddress" => "test_112345455433@domain.org",
-                "displayName" => "user display name",
-                "active" => true
-            ]
-        );
+        $user = $client->updateUser([
+            'ApiVersion' => 'latest',
+            "username" => "test_user",
+            "emailAddress" => "test_112345455433@domain.org",
+            "displayName" => "user display name",
+            "active" => true
+        ]);
 
         $this->assertEquals("test_user", $user['key']);
     }
 
     public function testDeleteUser()
     {
-        $config = include 'config-test.php';
+        $mockBody = '{}';
 
-        $client = new Client($config);
-
-        $mockBody = Stream::factory('{}');
-
-        $mock = new Mock(
-            [
-                new Response(204, [], $mockBody),
-            ]
-        );
-
-        // Add the mock subscriber to the client.
-        $client->getHttpClient()->getEmitter()->attach($mock);
+        $client = $this->getMockClient($mockBody, 204);
 
         // Call get user and make sure we get back the user we expect from mock
-        $user = $client->deleteUser(
-            [
-                "username" => "test_user",
-            ]
-        );
+        $user = $client->deleteUser([
+            'ApiVersion' => 'latest',
+            "username" => "test_user",
+        ]);
 
         $this->assertEquals(204, $user['statusCode']);
-
     }
 
     public function testSearchForUserByEmail()
     {
-        $config = include 'config-test.php';
+        $mockBody = json_encode([
+            "self" => "http://www.example.com/jira/rest/api/2/user?username=test_user",
+            "avatarUrls"=> [
+                "24x24" => "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred",
+                "16x16" => "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred",
+                "32x32" => "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred",
+                "48x48" => "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred"
+            ],
+            "name" => "test_user",
+            "key" => "test_user",
+            "emailAddress" => "test_user@domain.org",
+            "displayName"=> "Test User",
+            "active" => true
+        ]);
 
-        $client = new Client($config);
-
-        $mockBody = Stream::factory(
-            json_encode(
-                [
-                    "self" => "http://www.example.com/jira/rest/api/2/user?username=test_user",
-                    "avatarUrls"=> [
-                        "24x24" => "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred",
-                        "16x16" => "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred",
-                        "32x32" => "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred",
-                        "48x48" => "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred"
-                    ],
-                    "name" => "test_user",
-                    "key" => "test_user",
-                    "emailAddress" => "test_user@domain.org",
-                    "displayName"=> "Test User",
-                    "active" => true
-                ]
-            )
-        );
-
-
-        $mock = new Mock(
-            [
-                new Response(200, [], $mockBody),
-            ]
-        );
-
-        // Add the mock subscriber to the client.
-        $client->getHttpClient()->getEmitter()->attach($mock);
+        $client = $this->getMockClient($mockBody, 200);
 
         // Call get user and make sure we get back the user we expect from mock
-        $user = $client->searchForUser(
-            [
-                "username" => "test_user",
-            ]
-        );
+        $user = $client->searchForUser([
+            'ApiVersion' => 'latest',
+            "username" => "test_user",
+        ]);
 
         $this->assertEquals("test_user", $user['key']);
+    }
+
+    /**
+     * @param $mockBody
+     * @return Client
+     */
+    private function getMockClient($mockBody, $responseCode)
+    {
+        $config = include 'config-test.php';
+
+        $mockHandler = new MockHandler([
+            new Response($responseCode, [], $mockBody),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $client = new Client(array_merge([
+            'http_client_options' => [
+                'handler' => $handlerStack,
+            ]
+        ], $config));
+        return $client;
     }
 }


### PR DESCRIPTION
required changes:
- `guzzlehttp/retry-subscriber` was removed, so no automatic API retries
- http client is now immutable, so credentials are applied to config before client creation 
- `setConfig` changed how arguments are passed (slash-separated to nested array)
- test mocks are created differently